### PR TITLE
Enable playing with local templates 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,11 @@
   "name": "meikit",
   "version": "0.0.3",
   "description": "",
-  "main": "./dist",
   "bin": "./dist/cli.js",
   "scripts": {
     "build": "npm run clean && babel src --out-dir dist",
     "prepack": "npm run build",
-    "start": "babel-node src/index.js",
+    "start": "babel-node src/cli.js",
     "clean": "rm -Rf dist",
     "phoenix": "rm -Rf node_modules && rm -Rf package-lock.json && npm i",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -25,6 +24,7 @@
     "handlebars": "^4.5.3",
     "handlebars-helpers": "^0.10.0",
     "inquirer": "^7.0.0",
+    "meow": "^5.0.0",
     "shelljs": "^0.8.3"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,42 @@
 #!/usr/bin/env node
 
+const main = require('./main')
+const meow = require('meow')
+
+const cli = meow(`
+Usage
+$ npx meik [path to meik template] [options]
+
+Options
+  --local The path to meik template is a local folder instead of a Git URL
+  --test  Nothing to be generated, just test the template
+
+Examples
+
+$ npx meik https://github.com/meikit/meikit-sample-js-lib-template.git
+
+$ npx meik ./my-template --local
+`, {
+  flags: {
+    local: {
+      type: 'boolean',
+      default: false
+    },
+    test: {
+      type: 'boolean',
+      default: false
+    }
+  }
+})
+
+if (!(cli.input.length > 0 && cli.input[0])) {
+  cli.showHelp(1)
+}
+
 Promise.resolve()
-  .then(() => require('./index'))
+  .then(() => main({
+    source: cli.input[0],
+    options: cli.flags
+  }))
+  .catch(error => console.error(error))
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,0 @@
-Promise.resolve()
-  .then(require('./main'))
-  .catch(error => console.log(error))

--- a/src/main.js
+++ b/src/main.js
@@ -13,15 +13,16 @@ const meikit = require('./meikit')
 
 let cleanFolders = []
 
-run()
+const main = ({source, options}) => run({source, options})
   .then(() => LOG('[done]'))
   .catch(error =>  LOG('[error]', error))
   .then(() => cleanFolders.forEach(folder => clean({folder})))
 
-async function run() {
-  const {source, target} = await ask()
-  const {targetFolder, templateFolder} = prepare({source, target})
-  cleanFolders.push(templateFolder)
+async function run({source, options}) {
+  LOG('[meikit]', source, options)
+  const {target} = await ask()
+  const {targetFolder, templateFolder} = prepare({source, target, ...options})
+  !options.local && cleanFolders.push(templateFolder)
   const model = await createModel({templateFolder})
   const sourceBaseFolder = path.join(templateFolder, 'template')
 
@@ -36,7 +37,8 @@ async function run() {
     model,
     file: templateFile,
     sourceBaseFolder,
-    targetBaseFolder: targetFolder
+    targetBaseFolder: targetFolder,
+    test: options.test
   }))
 }
 
@@ -44,25 +46,28 @@ async function ask() {
   return inquirer.prompt(meikit.questions)
 }
 
-function prepare({source, target}) {
+function prepare({source, target, local, test}) {
   LOG('[prepare]', source, target)
-  const targetFolder = path.resolve(path.join(PWD, target))
-  const templateFolder = `${targetFolder}_meikit_template`
 
-  if (fs.existsSync(targetFolder)) {
+  const targetFolder = path.resolve(path.join(PWD, target))
+  if (!test && fs.existsSync(targetFolder)) {
     throw new Error('Already exists: ' + targetFolder)
   }
-  if (fs.existsSync(templateFolder)) {
-    throw new Error('Already exists: ' + templateFolder)
+  !test && fs.ensureDirSync(targetFolder)
+
+  let templateFolder
+  if (!local) {
+    templateFolder = `${targetFolder}_meikit_template`
+    if (fs.existsSync(templateFolder)) {
+      throw new Error('Already exists: ' + templateFolder)
+    }
+    fs.ensureDirSync(templateFolder)
+    const command = `git clone ${source} ${templateFolder}`
+    LOG('[loading source]', command)
+    shell.exec(command)
+  } else {
+    templateFolder = path.resolve(path.join(PWD, source))
   }
-
-  fs.ensureDirSync(targetFolder)
-  fs.ensureDirSync(templateFolder)
-
-  const command = `git clone ${source} ${templateFolder}`
-  LOG('[loading source]', command)
-  shell.exec(command)
-
   return {
     targetFolder,
     templateFolder
@@ -116,7 +121,7 @@ function loadFilePaths({folder}) {
   return accumulated
 }
 
-function processFile({model, file, sourceBaseFolder, targetBaseFolder}) {
+function processFile({model, file, sourceBaseFolder, targetBaseFolder, test}) {
   const shortPath = (path) => path.replace(sourceBaseFolder + '/', '')
   const isTemplate = file.endsWith('.meikit')
   const targetFile = handlebars.compile(file)(model).replace(/.meikit$/, '')
@@ -128,12 +133,16 @@ function processFile({model, file, sourceBaseFolder, targetBaseFolder}) {
   const source = fs.readFileSync(file, {encoding: 'utf8'})
   const target = isTemplate ? handlebars.compile(source)(model) : source
 
-  const targetDestination = path.join(targetBaseFolder, targetShortPath)
-  const targetDestinationFolder = path.dirname(targetDestination)
+  if (!test) {
+    const targetDestination = path.join(targetBaseFolder, targetShortPath)
+    const targetDestinationFolder = path.dirname(targetDestination)
 
-  if (!fs.existsSync(targetDestinationFolder)) {
-    fs.ensureDirSync(targetDestinationFolder)
+    if (!fs.existsSync(targetDestinationFolder)) {
+      fs.ensureDirSync(targetDestinationFolder)
+    }
+
+    fs.writeFileSync(targetDestination, target, {encoding: 'utf8'})
   }
-
-  fs.writeFileSync(targetDestination, target, {encoding: 'utf8'})
 }
+
+module.exports = main

--- a/src/meikit.js
+++ b/src/meikit.js
@@ -2,11 +2,6 @@ const notEmpty = input => (input && input.length > 0) || 'Cannot be empty'
 
 const questions = [
   {
-    name: 'source',
-    message: '(*) MeikIT template github\'s repository:',
-    validate: notEmpty
-  },
-  {
     name: 'target',
     message: '(*) Target folder:',
     validate: notEmpty


### PR DESCRIPTION
## Description
<!--- Explain why this PR has to be merged, what originated this feature, ... -->

This PR enables:
* command line help and argument parsing
* passing the source template (git url or local folder) directly
* passing the --local flag to indicate that the template is local and no needs to be cloned
* passing the --test flag to indicate that the generated files must not be written (only test the model against the template files and paths evaluators)

